### PR TITLE
Fixed df when partition has a long name (as LVM generic) 

### DIFF
--- a/check_diskpath_status.plx
+++ b/check_diskpath_status.plx
@@ -7,19 +7,19 @@ use strict;
 # Author : Priyadarshee D. Kumar
 # Date : 25/12/2012
 # Purpose : To check the used disk space and used inode limit using df on path or mountpoint.
-#	    It takes the mountpoint/path as the second argument.	
+#	    It takes the mountpoint/path as the second argument.
 # Usage : It accepts 3 arguments, warnings limit and critical limit
 #         If used %age is more than -w value it will give warning message
 #         If used %age is more that -c value it will give critical message
 #
-# Syntax : check_disk.plx [PathToCheck] -w [WarnLimit] -c [CritLimit]       
-#   
+# Syntax : check_disk.plx [PathToCheck] -w [WarnLimit] -c [CritLimit]
+#
 # Reason for this : In some cases (e.g. virtuzoo container in my case),
 #               the default check_disk plugin comes with nagios doesnt work
 # 	            The df,mount,procfs dont show properly mounted
 # 	            device,filesystems,sizes. So I have to use df <path>/mountpoint
 #		    to get the details which is fed into this plugin to get values.
-# 			
+#
 # 	            It also works on all unix/linux systems also.
 #########################################################################################
 $#ARGV += 1;
@@ -73,7 +73,7 @@ if ($Dpused >= $crit || $Ipused >= $crit){
 
 
 sub disk{
-open (FH, "df -kh $path |") || die "Unable to run df on $path : $!\n";
+open (FH, "df -kh $path | sed 1d | tr -s '\n' ' ' |") || die "Unable to run df on $path : $!\n";
 while (<FH>){
        		if (/(\S+)\s+(\d+.*\d*[A-Z])\s+(\d+.*\d*[A-Z])\s+(\d+.*\d*[A-Z])\s+(\d+.*\d*)%\s+(.*)/){
 		my $Device = $1;
@@ -84,7 +84,7 @@ while (<FH>){
 		my $MPoint = $6;
 		chomp($Device,$DSize,$DUsed,$DAvail,$DPUsed,$MPoint);
 #		print "\n$Device\n$DSize\n$DUsed\n$DAvail\n$DPUsed\n$MPoint\n";
-                return ("$DPUsed","$DAvail");		
+                return ("$DPUsed","$DAvail");
 		next;
 		}
     }
@@ -92,7 +92,7 @@ while (<FH>){
 
 
 sub inode{
-open (FH1, "df -ih $path |") || die "Unable to run df on $path : $!\n";
+open (FH1, "df -ih $path | sed 1d | tr -s '\n' ' ' |") || die "Unable to run df on $path : $!\n";
 while (<FH1>){
        		if (/(\S)\s+(\d+.*\d*[A-Z])\s+(\d+.*\d*[A-Z])\s+(\d+.*\d*[A-Z])\s+(\d+.*\d*)%\s+(.*)/){
                 my $Device = $1;
@@ -106,5 +106,5 @@ while (<FH1>){
 		return ("$IPUsed","$IAvail");
 		next;
 		}
-    }			
-}		
+    }
+}


### PR DESCRIPTION
## check_diskpath_status.plx

Fixed df when partition has a long name (as LVM generic)  with auto \n introduced by df.

For example, if you have "/dev/mapper/VolGroup00-LogVol00" as LVM name, df add \n at the end of the name for print correctly others cols like free space, usage etc...